### PR TITLE
Add download-pickles target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ link-data:
 	# create symlinks from original data store
 	ln -sf /projects/HASSON/247/data/conversations-car/* data/
 
+download-pickles:
+	mkdir -p results/{625,676}
+	gsutil -m rsync -x "^(?!.*625).*" gs://247-podcast-data/247_pickles/ results/625/
+	gsutil -m rsync -x "^(?!.*676).*" gs://247-podcast-data/247_pickles/ results/676/
+	cp /scratch/gpfs/zzada/247-pickling/results/625/625_gpt2_cnxt_1024_embeddings.pkl results/625/
 
 create-pickle: link-data
 	mkdir -p logs

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ download-pickles:
 	mkdir -p results/{625,676}
 	gsutil -m rsync -x "^(?!.*625).*" gs://247-podcast-data/247_pickles/ results/625/
 	gsutil -m rsync -x "^(?!.*676).*" gs://247-podcast-data/247_pickles/ results/676/
-	cp /scratch/gpfs/zzada/247-pickling/results/625/625_gpt2_cnxt_1024_embeddings.pkl results/625/
 
 create-pickle: link-data
 	mkdir -p logs


### PR DESCRIPTION
Add a target to download pickles using `gsutil` instead of creating your own.